### PR TITLE
Fix environment reference numbering

### DIFF
--- a/src/environments.typ
+++ b/src/environments.typ
@@ -19,10 +19,6 @@
   breakable: true,
 )
 
-#let _env_state = state("env", (:))
-
-#let _reset_env_counting() = _env_state.update(it => it.keys().map(k => (k, 0)).to-dict())
-
 #let accent-frame-heading(config, it) = {
   set text(
     font: config._sans_font,
@@ -105,43 +101,48 @@
   body,
   label: none,
   numbered: true,
-) = [
-  #_env_state.update(it => it + (str(kind): it.at(kind, default: 0) + 1))
-  #show figure.where(kind: kind): set block(breakable: true)
-  #show figure.where(kind: kind): set par(spacing: config._envskip)
-  #let i18n = config.i18n.at(kind)
-  #let (name, supplement) = if type(i18n) == dictionary {
+) = context {
+  let i18n = config.i18n.at(kind)
+  let (name, supplement) = if type(i18n) == dictionary {
     (i18n.name, i18n.supplement)
   } else if type(i18n) == str {
     (i18n, i18n)
   } else { panic("Invalid i18n entry for kind: " + kind) }
-  
-  #figure(
-    kind: kind,
-    supplement: supplement,
-    placement: none,
-    caption: none,
-    {
-      set align(left)
-      topdeco(config)
-      block(
-        breakable: true,
-        ..frame(config),
-        [
-          #heading(if numbered {
-            let num = context [#current_chapter().index.at(0).#_env_state.get().at(kind)]
-            [#name#h(.3em) #num #h(.5em) #title]
-          } else {
-            name + h(.5em) + title
-          })
-          #body
-        ],
-      )
-      bottomdeco(config)
-    },
-  ) #label
-]
 
+  let chap = current_chapter().index.at(0)
+  let env_cnt = counter("env-" + kind + "-" + str(chap))
+  let num = [#chap.#{ env_cnt.get().at(0) + 1 }]
+
+  show figure.where(kind: kind): set block(breakable: true)
+  show figure.where(kind: kind): set par(spacing: config._envskip)
+  [
+    #figure(
+      kind: kind,
+      supplement: supplement,
+      placement: none,
+      caption: none,
+      numbering: (..) => { if numbered { num } },
+      {
+        set align(left)
+        topdeco(config)
+        block(
+          ..frame(config),
+          [
+            #heading(if numbered {
+              [#name#h(.3em) #num #h(.5em) #title]
+            } else {
+              name + h(.5em) + title
+            })
+            #body
+          ],
+        )
+        bottomdeco(config)
+      },
+    )
+    #label
+    #env_cnt.step()
+  ]
+}
 
 #let _remark(config, ..args) = environment(
   config,

--- a/src/template.typ
+++ b/src/template.typ
@@ -1,7 +1,6 @@
 #import "components.typ": *
 #import "packages/marginalia.typ": *
 #import "index.typ": use_word_list
-#import "environments.typ": _env_state, _reset_env_counting
 
 #let _page_geo(config) = (
   inner: (far: config._page_margin, width: 0mm, sep: 0mm),
@@ -18,7 +17,6 @@
   counter(figure.where(kind: table)).update(0)
   counter(figure.where(kind: image)).update(0)
   counter(figure.where(kind: raw)).update(0)
-  _reset_env_counting()
   justify-page()
 }
 


### PR DESCRIPTION
Environment references numbering is incorrect.

main.typ:

```typ
#import "uwnibook.typ": *

#titlepage

#show: template

#mainbody[
  #include "chapters/1.typ"
  #include "chapters/2.typ"
]

#appendix[
  #include "chapters/appendix.typ"
]
```

chapters/1.typ:

```typ
#import "../uwnibook.typ": *

= 第一章

#example(title: "Example", label: <e1.1>)[Example 1]

#example(title: "Example", label: <e1.2>)[Example 2]
```

chapters/2.typ:

```typ
#import "../uwnibook.typ": *

= 第二章

#example(title: "Example", label: <e2.1>)[Example 1]

#example(title: "Example", label: <e2.2>)[Example 2]
```

chapters/appendix.typ:

```typ
= 引用

#ref(<e1.1>)
#ref(<e1.2>)
#ref(<e2.1>)
#ref(<e2.2>)
```

Current:

<img width="420" height="294" alt="QQ_1772604555510" src="https://github.com/user-attachments/assets/37dd71c3-4faa-4d28-8d85-df83d81a195a" />

Expected: 

```plain
例 1.1 例 1.2 例 2.1 例 2.2
```
